### PR TITLE
Replace Deprecated People API

### DIFF
--- a/server/ui.go
+++ b/server/ui.go
@@ -30,7 +30,7 @@ import (
 
 	uuid "github.com/gofrs/uuid"
 	option "google.golang.org/api/option"
-	plus "google.golang.org/api/plus/v1"
+	plus "google.golang.org/api/people/v1"
 
 	"github.com/google/web-api-gateway/config"
 	"github.com/gorilla/mux"


### PR DESCRIPTION
Plus api was deprecated and replace by import "google.golang.org/api/people/v1"